### PR TITLE
chore: ts-config verbatimModuleSyntax true

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -101,6 +101,7 @@
 		"@ethereum-attestation-service/eas-contracts": "1.7.1",
 		"@faker-js/faker": "^8.2.0",
 		"@fleek-platform/cli": "^3.8.2",
+		"@geist/typescript-config": "workspace:*",
 		"@radix-ui/themes": "^3.1.4",
 		"@storybook/addon-essentials": "^8.3.4",
 		"@storybook/addon-interactions": "^8.3.4",

--- a/apps/storybook/src/stories/account/Balance.stories.tsx
+++ b/apps/storybook/src/stories/account/Balance.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { BY_USER } from "@geist/domain/user.fixture";
 import { Balance } from "@geist/ui-react/components/account/balance";
 import { BY_CHAIN_ID, Token } from "@geist/ui-react/lib/token/config";
-import { Address } from "viem";
+import type { Address } from "viem";
 import { base, optimism } from "viem/chains";
 import { withWagmiProvider } from "../decorators/wagmi";
 

--- a/apps/storybook/src/stories/decorators/wagmi.tsx
+++ b/apps/storybook/src/stories/decorators/wagmi.tsx
@@ -1,7 +1,7 @@
 import { BY_USER, getRandomAccount } from "@geist/domain/user.fixture";
 import { WAGMI_CONFIG } from "@geist/ui-react/lib/utils/wagmi-config";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Hex } from "viem";
+import type { Hex } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { WagmiProvider, useAccount, useConnect, useWalletClient } from "wagmi";
 

--- a/apps/storybook/src/stories/identity/AddressBadge.stories.tsx
+++ b/apps/storybook/src/stories/identity/AddressBadge.stories.tsx
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { AddressBadge } from "@geist/ui-react/components/identity/address-badge";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Hex } from "viem";
+import type { Hex } from "viem";
 
 const meta = {
 	title: "Identity/AddressBadge",

--- a/apps/storybook/src/stories/signature/SignatureForm.stories.tsx
+++ b/apps/storybook/src/stories/signature/SignatureForm.stories.tsx
@@ -15,7 +15,11 @@ import { sepolia } from "viem/chains";
 import { useSignMessage } from "wagmi";
 import { withMockAccount, withWagmiProvider } from "../decorators/wagmi";
 
-import { Hex, SignAccountType, SignType } from "@geist/domain/signature/sign";
+import {
+	type Hex,
+	SignAccountType,
+	SignType,
+} from "@geist/domain/signature/sign";
 import { ScrollableCodeBlock } from "@geist/ui-react/components/scrollable-code-block";
 import { SignatureVerifyBadge } from "@geist/ui-react/components/signature/signature-verify-badge";
 

--- a/apps/storybook/src/stories/signature/SignatureFormMin.stories.tsx
+++ b/apps/storybook/src/stories/signature/SignatureFormMin.stories.tsx
@@ -1,4 +1,4 @@
-import { Hex, SignType } from "@geist/domain/signature/sign";
+import { type Hex, SignType } from "@geist/domain/signature/sign";
 import { TYPED_DATA } from "@geist/domain/signature/type-data";
 import { ScrollableCodeBlock } from "@geist/ui-react/components/scrollable-code-block";
 import { SignatureForm } from "@geist/ui-react/components/signature/signature-form";

--- a/apps/storybook/src/stories/transfer-button/TransferButton.stories.tsx
+++ b/apps/storybook/src/stories/transfer-button/TransferButton.stories.tsx
@@ -1,7 +1,7 @@
 import { TransferButton } from "@geist/ui-react/components/transfer/transfer-button";
 import { Meta, StoryObj } from "@storybook/react";
 import { useMemo, useState } from "react";
-import { Account } from "viem";
+import type { Account } from "viem";
 import { Label } from "#components/ui/label";
 import { withMockAccount, withWagmiProvider } from "../decorators/wagmi";
 interface TransferButtonProps {

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "@geist/typescript-config/base.json",
 	"compilerOptions": {
 		"baseUrl": "."
 	},

--- a/packages/domain/src/chain/chain-resolver.ts
+++ b/packages/domain/src/chain/chain-resolver.ts
@@ -1,4 +1,4 @@
-import { Chain, extractChain } from "viem";
+import { type Chain, extractChain } from "viem";
 import {
 	arbitrum,
 	arbitrumGoerli,

--- a/packages/domain/src/signature/sign.ts
+++ b/packages/domain/src/signature/sign.ts
@@ -1,9 +1,7 @@
 // ECDSA signatures over secp256k1
 
 import { sha256 } from "@noble/hashes/sha256";
-import { signMessage } from "@wagmi/core";
 import { useEffect, useRef, useState } from "react";
-import { useAccount, useConfig, useSignMessage } from "wagmi";
 
 import * as typed from "micro-eth-signer/typed-data";
 

--- a/packages/domain/src/token/token.ts
+++ b/packages/domain/src/token/token.ts
@@ -1,0 +1,8 @@
+export type Token = {
+	address?: Address;
+	imageUrl?: string;
+	decimals: number;
+	name: string;
+	symbol: string;
+	type?: string;
+};

--- a/packages/domain/src/transaction/transaction.ts
+++ b/packages/domain/src/transaction/transaction.ts
@@ -1,5 +1,5 @@
-import { Address, Transaction } from "viem";
-import { Token } from "../token/token";
+import type { Transaction } from "viem";
+import type { Token } from "#token/token";
 
 // ignore other meta such as supply / volume for now
 export type TokenTransfer = Token & {

--- a/packages/domain/src/user.fixture.ts
+++ b/packages/domain/src/user.fixture.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { addr } from "micro-eth-signer";
-import { Address, Hex } from "viem";
+import type { Address, Hex } from "viem";
 import config from "./config";
 
 const vitalik = {

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -15,6 +15,7 @@
 		"moduleDetection": "force",
 		"moduleResolution": "NodeNext",
 		"noUncheckedIndexedAccess": true,
+		"verbatimModuleSyntax": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/packages/ui-react/src/components/account/balance.tsx
+++ b/packages/ui-react/src/components/account/balance.tsx
@@ -2,7 +2,7 @@ import { formatUnitsWithDecimalsDisplayed } from "@geist/domain/amount";
 import { Text } from "@radix-ui/themes";
 // support ENS, basename
 // Option to use ipfs gateway, ens metadata services
-import { Address } from "viem";
+import type { Address } from "viem";
 import { mainnet } from "viem/chains";
 import { useBalance, useReadContract } from "wagmi";
 import { ABI_ERC20 } from "#lib/token/config";

--- a/packages/ui-react/src/components/attestations/attestation-badge.tsx
+++ b/packages/ui-react/src/components/attestations/attestation-badge.tsx
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { type Address } from "viem";
 import { useChainId } from "wagmi";
 import { Badge } from "#components/shadcn/badge";
 import { useGetAttestations } from "#hooks/eas/use-get-attestations";

--- a/packages/ui-react/src/components/attestations/attestation-card.tsx
+++ b/packages/ui-react/src/components/attestations/attestation-card.tsx
@@ -1,7 +1,7 @@
 import { Label } from "@radix-ui/react-label";
 import { format } from "date-fns";
 import { useMemo } from "react";
-import { Address, Hex } from "viem";
+import { type Address, Hex } from "viem";
 import { mainnet } from "viem/chains";
 import { useChainId } from "wagmi";
 import {

--- a/packages/ui-react/src/components/attestations/attestation-form.tsx
+++ b/packages/ui-react/src/components/attestations/attestation-form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { Address } from "viem";
+import type { Address } from "viem";
 import { z } from "zod";
 import { Button } from "#components/shadcn/button";
 import { Card, CardContent } from "#components/shadcn/card";

--- a/packages/ui-react/src/components/attestations/attestations-table.tsx
+++ b/packages/ui-react/src/components/attestations/attestations-table.tsx
@@ -1,6 +1,6 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
-import { Address, fromBlobs } from "viem";
+import { type Address, fromBlobs } from "viem";
 import { mainnet } from "viem/chains";
 import { useChainId } from "wagmi";
 import { DataTable } from "#components/data-table";

--- a/packages/ui-react/src/components/attestations/attestations.ts
+++ b/packages/ui-react/src/components/attestations/attestations.ts
@@ -1,5 +1,5 @@
 import { format, formatDistance, subDays } from "date-fns";
-import { Address } from "viem";
+import type { Address } from "viem";
 import { AttestationQueryResult } from "#hooks/eas/use-get-attestations";
 
 // TODO sync graphql type

--- a/packages/ui-react/src/components/identity/address-badge.tsx
+++ b/packages/ui-react/src/components/identity/address-badge.tsx
@@ -1,6 +1,6 @@
 import { Check, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Hex, getAddress } from "viem";
+import { type Hex, getAddress } from "viem";
 import { normalize } from "viem/ens";
 import { useEnsAddress } from "wagmi";
 import {

--- a/packages/ui-react/src/components/identity/name-wagmi.tsx
+++ b/packages/ui-react/src/components/identity/name-wagmi.tsx
@@ -1,9 +1,9 @@
 // Take in address and display
 
 import { useEffect, useMemo, useState } from "react";
-import { Address, isHex } from "viem";
+import { type Address, isHex } from "viem";
 import { useEnsName } from "wagmi";
-import { AddressOrEns } from "#hooks/ens/efp";
+import type { AddressOrEns } from "#hooks/ens/efp";
 
 export const NameWagmi = ({ addressOrEns }: { addressOrEns: AddressOrEns }) => {
 	const isName = !isHex(addressOrEns);

--- a/packages/ui-react/src/components/signature/signature-verify-badge.tsx
+++ b/packages/ui-react/src/components/signature/signature-verify-badge.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
-import { Address, Hex } from "viem";
+import type { Address, Hex } from "viem";
 import { AddressBadge } from "#components/identity/address-badge";
 import { Label } from "#components/shadcn/label";
 export const SignatureVerifyBadge = ({

--- a/packages/ui-react/src/components/token/token-chip.tsx
+++ b/packages/ui-react/src/components/token/token-chip.tsx
@@ -1,4 +1,4 @@
-import { Address, Chain, erc20Abi } from "viem";
+import { type Address, Chain, erc20Abi } from "viem";
 import { mainnet } from "viem/chains";
 import { useConfig } from "wagmi";
 import { useTokenInfo } from "./token";

--- a/packages/ui-react/src/components/token/token.ts
+++ b/packages/ui-react/src/components/token/token.ts
@@ -13,18 +13,10 @@
 
 import { resolveProductionChain } from "@geist/domain/chain/chain-resolver";
 // import { useReadContracts } from "wagmi";
-import { Config, readContracts } from "@wagmi/core";
+import { type Config, readContracts } from "@wagmi/core";
 import { useEffect, useState } from "react";
-import { Address, Chain, erc20Abi } from "viem";
-
-export type Token = {
-	address?: Address;
-	imageUrl?: string;
-	decimals: number;
-	name: string;
-	symbol: string;
-	type?: string;
-};
+import { type Address, type Chain, erc20Abi } from "viem";
+import { asTrustWalletChainName } from "#lib/trustwallet-chain.js";
 
 /**
  * trustwallet/assets does not contains most testnet, always fallback to mainnet

--- a/packages/ui-react/src/components/transactions/transaction-card-with-details.tsx
+++ b/packages/ui-react/src/components/transactions/transaction-card-with-details.tsx
@@ -1,3 +1,4 @@
+import type { Token } from "@geist/domain/token/token";
 import { TransactionMeta } from "@geist/domain/transaction/transaction";
 import { Label } from "@radix-ui/react-label";
 import { AddressBadge } from "#components/identity/address-badge";
@@ -12,7 +13,6 @@ import {
 import { Separator } from "#components/shadcn/separator";
 import { Skeleton } from "#components/shadcn/skeleton";
 import { TokenChipWithInfo } from "#components/token/token-chip-with-info";
-import { Token } from "#lib/token/token";
 import { getShortHex } from "#lib/utils/hex";
 
 export const TransactionSummary = ({

--- a/packages/ui-react/src/components/transactions/transaction-card.tsx
+++ b/packages/ui-react/src/components/transactions/transaction-card.tsx
@@ -1,4 +1,4 @@
-import { Chain } from "viem";
+import type { Chain } from "viem";
 import { mainnet } from "viem/chains";
 import { useConfig } from "wagmi";
 import { Skeleton } from "#components/shadcn/skeleton";

--- a/packages/ui-react/src/hooks/data/use-blockscout.ts
+++ b/packages/ui-react/src/hooks/data/use-blockscout.ts
@@ -1,3 +1,4 @@
+import type { TransactionMeta } from "@geist/domain/transaction/transaction";
 import { useQuery } from "@tanstack/react-query";
 import {
 	GetTxnByFilterQuery,
@@ -5,7 +6,6 @@ import {
 	getTransaction,
 	getTxnsByFilter,
 } from "#lib/blockscout/api";
-import { TransactionMeta } from "#lib/domain/transaction/transaction";
 
 export const CACHE_KEY = "blockscout";
 

--- a/packages/ui-react/src/hooks/eas/use-attestation.ts
+++ b/packages/ui-react/src/hooks/eas/use-attestation.ts
@@ -2,17 +2,17 @@ import { NO_EXPIRATION } from "@geist/ui-react/lib/eas/request";
 import { OffchainAttestationVersion } from "@geist/ui-react/lib/eas/sdk/offchain/offchain";
 import { signOffchainAttestation } from "@geist/ui-react/lib/eas/viem/offchain";
 import {
-	AttestationRequestData,
+	type AttestationRequestData,
 	makeOnchainAttestation,
 } from "@geist/ui-react/lib/eas/viem/onchain";
 import { createTestClientConfig } from "@geist/ui-react/lib/test-utils-isomorphic";
 import { useMemo } from "react";
 import {
-	Account,
-	Address,
-	Chain,
-	Hex,
-	TransactionReceipt,
+	type Account,
+	type Address,
+	type Chain,
+	type Hex,
+	type TransactionReceipt,
 	createWalletClient,
 	stringToHex,
 	zeroHash,

--- a/packages/ui-react/src/hooks/eas/use-get-attestation-with-uid.tsx
+++ b/packages/ui-react/src/hooks/eas/use-get-attestation-with-uid.tsx
@@ -1,5 +1,5 @@
-import { Attestation } from "@geist/graphql/eas/graphql";
-import { QueryClient, UseQueryResult, useQuery } from "@tanstack/react-query";
+import { type Attestation } from "@geist/graphql/eas/graphql";
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { gql, rawRequest } from "graphql-request";
 import { getEasscanEndpoint } from "#lib/eas/easscan";
 

--- a/packages/ui-react/src/hooks/eas/use-get-attestations.int.test.tsx
+++ b/packages/ui-react/src/hooks/eas/use-get-attestations.int.test.tsx
@@ -5,7 +5,7 @@ import { useGetAttestations } from "./use-get-attestations";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
-import { Address } from "viem";
+import type { Address } from "viem";
 
 /**
  * @vitest-environment jsdom

--- a/packages/ui-react/src/hooks/eas/use-get-attestations.ts
+++ b/packages/ui-react/src/hooks/eas/use-get-attestations.ts
@@ -2,7 +2,7 @@ import { gql } from "@geist/graphql";
 import type { Attestation } from "@geist/graphql/eas/graphql";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import { rawRequest, request } from "graphql-request";
-import { Address, Hex } from "viem";
+import { type Address, Hex } from "viem";
 import { getEasscanEndpoint } from "#lib/eas/easscan";
 
 const allAttestationsByQuery = gql(`

--- a/packages/ui-react/src/hooks/ens/efp.ts
+++ b/packages/ui-react/src/hooks/ens/efp.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import type { Address } from "viem";
 
 export type AddressOrEns = Address | string;
 

--- a/packages/ui-react/src/hooks/ens/use-efp-api.ts
+++ b/packages/ui-react/src/hooks/ens/use-efp-api.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Address } from "viem";
+import type { Address } from "viem";
 import {
 	AddressOrEns,
 	EfpApiOptions,

--- a/packages/ui-react/src/hooks/signature/use-sign.ts
+++ b/packages/ui-react/src/hooks/signature/use-sign.ts
@@ -12,7 +12,7 @@ import { useAccount, useConfig, useSignMessage } from "wagmi";
 import { atom, useAtom } from "jotai";
 import { addr } from "micro-eth-signer";
 
-import { Hex, SignType } from "@geist/domain/signature/sign";
+import { type Hex, SignType } from "@geist/domain/signature/sign";
 import { TYPED_DATA } from "@geist/domain/signature/type-data";
 import { useMemo } from "react";
 import type { Address } from "viem";

--- a/packages/ui-react/src/lib/blockscout/api.ts
+++ b/packages/ui-react/src/lib/blockscout/api.ts
@@ -2,7 +2,7 @@ import {
 	TokenTransfer,
 	TransactionMeta,
 } from "@geist/domain/transaction/transaction";
-import { Address, parseUnits } from "viem";
+import { type Address, parseUnits } from "viem";
 import * as chains from "viem/chains";
 
 const chainIdToApiRoot: any = {

--- a/packages/ui-react/src/lib/blockscout/chain.ts
+++ b/packages/ui-react/src/lib/blockscout/chain.ts
@@ -1,7 +1,7 @@
 // explorer url in chainInfo.ts are pulled from  https://github.com/blockscout/chainscout/blob/main/data/chains.json
 // https://www.blockscout.com/chains-and-projects
 
-import { Chain } from "viem";
+import type { Chain } from "viem";
 import { BLOCKSCOUT_CHAINS_BY_ID } from "./chainInfo";
 
 // TODO ensure treeshaking

--- a/packages/ui-react/src/lib/eas/abi.ts
+++ b/packages/ui-react/src/lib/eas/abi.ts
@@ -1,7 +1,7 @@
 // We should find a space efficient, composable way to organize abi by contract versions & action
 // For now, use sepolia as canonical one
 
-import { Hex } from "viem";
+import type { Hex } from "viem";
 
 // TODO fix multi-chain later
 export const EAS_CONTRACT_ADDRESS =

--- a/packages/ui-react/src/lib/eas/easscan.ts
+++ b/packages/ui-react/src/lib/eas/easscan.ts
@@ -1,4 +1,4 @@
-import { Address, Chain } from "viem";
+import type { Address } from "viem";
 import { EAS_CONFIG_BY_CHAIN_ID } from "./config";
 
 export const getEasscanEndpoint = (chainId: number) => {

--- a/packages/ui-react/src/lib/eas/schema-encoder.test.ts
+++ b/packages/ui-react/src/lib/eas/schema-encoder.test.ts
@@ -1,5 +1,5 @@
 import { AbiCoder } from "ethers";
-import { Hex, encodeAbiParameters } from "viem";
+import { type Hex, encodeAbiParameters } from "viem";
 import { beforeEach, describe, expect, test } from "vitest";
 import { ZERO_ADDRESS } from "#lib/constants";
 import { SchemaEncoder as SchemaEncoderEasSdk } from "#lib/eas/sdk/offchain/schema-encoder";

--- a/packages/ui-react/src/lib/eas/sdk/offchain/offchain.ts
+++ b/packages/ui-react/src/lib/eas/sdk/offchain/offchain.ts
@@ -5,7 +5,7 @@ import type {
 	SignedOffchainAttestation,
 } from "@ethereum-attestation-service/eas-sdk";
 import { ZERO_ADDRESS } from "@geist/ui-react/lib/constants";
-import { Address, verifyMessage, verifyTypedData } from "viem";
+import { type Address, verifyMessage, verifyTypedData } from "viem";
 import { getOffchainUID } from "#lib/eas/sdk/offchain/offchain-utils";
 import { isDeepEqual } from "#lib/shadcn/utils";
 import {

--- a/packages/ui-react/src/lib/eas/typed-data.test.ts
+++ b/packages/ui-react/src/lib/eas/typed-data.test.ts
@@ -8,8 +8,8 @@ import {
 } from "@ethereum-attestation-service/eas-sdk";
 import { AbiCoder, keccak256 as keccak256Ethers, toUtf8Bytes } from "ethers";
 import {
-	Address,
-	Hex,
+	type Address,
+	type Hex,
 	encodeAbiParameters,
 	encodePacked,
 	keccak256,

--- a/packages/ui-react/src/lib/eas/viem/offchain.int.test.ts
+++ b/packages/ui-react/src/lib/eas/viem/offchain.int.test.ts
@@ -12,7 +12,7 @@ import config from "@geist/domain/config";
 import { BY_USER } from "@geist/domain/user.fixture";
 import { Signature, Signer, encodeBytes32String, ethers } from "ethers";
 import { http, Address, createWalletClient, custom, zeroHash } from "viem";
-import { Hex } from "viem";
+import type { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { optimismSepolia, sepolia } from "viem/chains";
 import { beforeEach, describe, expect, test } from "vitest";

--- a/packages/ui-react/src/lib/filecoin/lighthouse/isomorphic.ts
+++ b/packages/ui-react/src/lib/filecoin/lighthouse/isomorphic.ts
@@ -2,7 +2,7 @@ import kavach from "@lighthouse-web3/kavach";
 import lighthouse from "@lighthouse-web3/sdk";
 import { IUploadProgressCallback } from "@lighthouse-web3/sdk/dist/types";
 import ky, { DownloadProgress } from "ky";
-import { http, Account, createWalletClient } from "viem";
+import { http, type Account, createWalletClient } from "viem";
 import { sepolia } from "viem/chains";
 import { GatewayStrategy } from "#lib/filecoin/gateway-strategy";
 import { uploadFiles as uploadFilesLighthouse } from "#lib/filecoin/lighthouse/browser";

--- a/packages/ui-react/src/lib/filecoin/storacha/isomorphic.ts
+++ b/packages/ui-react/src/lib/filecoin/storacha/isomorphic.ts
@@ -28,7 +28,7 @@ import type { ServiceAbility } from "@web3-storage/w3up-client/types";
 import { create } from "@web3-storage/w3up-client";
 import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
 
-import config from "@geist/domain/src/config";
+import config from "@geist/domain/config";
 // enable sync methods
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha512";

--- a/packages/ui-react/src/lib/token/config.ts
+++ b/packages/ui-react/src/lib/token/config.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import type { Address } from "viem";
 import { base, mainnet, optimism, sepolia } from "viem/chains";
 
 export enum Token {

--- a/packages/ui-react/src/lib/utils/address.ts
+++ b/packages/ui-react/src/lib/utils/address.ts
@@ -3,7 +3,7 @@
 
 // checksum encoded
 
-import { Address, getAddress, isHex } from "viem";
+import { type Address, getAddress, isHex } from "viem";
 import { getShortHex } from "#lib/utils/hex";
 
 export type GetShortAddressReturnType = string | null;

--- a/packages/ui-react/src/lib/utils/hex.ts
+++ b/packages/ui-react/src/lib/utils/hex.ts
@@ -1,4 +1,4 @@
-import { Hex } from "viem";
+import type { Hex } from "viem";
 
 export type GetShortAddressReturnType = string | null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,15 @@ importers:
       '@ethereumjs/rlp':
         specifier: ^5.0.2
         version: 5.0.2
+      '@geist/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
+      '@geist/graphql':
+        specifier: workspace:*
+        version: link:../../packages/gql
+      '@geist/ui-react':
+        specifier: workspace:*
+        version: link:../../packages/ui-react
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -191,15 +200,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@geist/domain':
-        specifier: workspace:*
-        version: link:../../packages/domain
-      '@geist/graphql':
-        specifier: workspace:*
-        version: link:../../packages/gql
-      '@geist/ui-react':
-        specifier: workspace:*
-        version: link:../../packages/ui-react
       '@scure/base':
         specifier: ^1.1.9
         version: 1.1.9
@@ -324,6 +324,9 @@ importers:
       '@fleek-platform/cli':
         specifier: ^3.8.2
         version: 3.8.2(@types/node@22.10.2)(encoding@0.1.13)(typescript@5.7.2)
+      '@geist/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@radix-ui/themes':
         specifier: ^3.1.4
         version: 3.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -411,6 +414,9 @@ importers:
       '@ethereumjs/rlp':
         specifier: ^5.0.2
         version: 5.0.2
+      '@geist/graphql':
+        specifier: workspace:*
+        version: link:../gql
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -432,9 +438,6 @@ importers:
       '@privy-io/react-auth':
         specifier: ^1.95.2
         version: 1.95.2(@solana/web3.js@1.95.5(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.18)(bs58@5.0.0)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.23.8)
-      '@geist/graphql':
-        specifier: workspace:*
-        version: link:../gql
       '@scure/base':
         specifier: ^1.1.9
         version: 1.1.9
@@ -576,6 +579,12 @@ importers:
       '@ethereumjs/rlp':
         specifier: ^5.0.2
         version: 5.0.2
+      '@geist/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@geist/graphql':
+        specifier: workspace:*
+        version: link:../gql
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -702,12 +711,6 @@ importers:
       '@radix-ui/themes':
         specifier: ^3.1.6
         version: 3.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@geist/domain':
-        specifier: workspace:*
-        version: link:../domain
-      '@geist/graphql':
-        specifier: workspace:*
-        version: link:../gql
       '@scure/base':
         specifier: ^1.1.9
         version: 1.1.9


### PR DESCRIPTION
Refers to https://www.typescriptlang.org/tsconfig/verbatimModuleSyntax.html

- Motivation is to make dependency more obvious (import type only doesn't actually need that dependency)
- Make dappkit more resilient by aligning the default stricter config as in astro
- Apply base config to storoybook too

<sub><a href="https://huly.app/guest/geist?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlNGU0ZWYxNDRmNTg1YWU1MzJlZGUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZGVidWdnLWdlaXN0LTY3NDAzNjhlLTU0NTgxY2VhOWEtYmNhZDgwIn0.AGOZNwpR21YQF7Azhx5E9JrTNRiW29EvrZ3mDlWMtyE">Huly&reg;: <b>DAPPK-69</b></a></sub>