### PR TITLE
chore: biome use import type

### DIFF
--- a/apps/storybook/src/components/ui/badge.tsx
+++ b/apps/storybook/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
 import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/apps/storybook/src/components/ui/form.tsx
+++ b/apps/storybook/src/components/ui/form.tsx
@@ -1,11 +1,11 @@
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import {
 	Controller,
-	ControllerProps,
-	FieldPath,
-	FieldValues,
+	type ControllerProps,
+	type FieldPath,
+	type FieldValues,
 	FormProvider,
 	useFormContext,
 } from "react-hook-form";

--- a/apps/storybook/src/stories/attestations/AttestationFormEasSdk.stories.tsx
+++ b/apps/storybook/src/stories/attestations/AttestationFormEasSdk.stories.tsx
@@ -4,11 +4,11 @@ import { useAttestationEasSdk } from "@geist/ui-react/hooks/eas/sdk/use-attestat
 import { EAS_CONTRACT_ADDRESS } from "@geist/ui-react/lib/eas/abi";
 import { SCHEMA_BY_NAME } from "@geist/ui-react/lib/eas/attest.fixture";
 import { NO_EXPIRATION } from "@geist/ui-react/lib/eas/request";
-import { SchemaItem, createEAS } from "@geist/ui-react/lib/eas/sdk/eas";
+import { type SchemaItem, createEAS } from "@geist/ui-react/lib/eas/sdk/eas";
 import { createTestEthersSigner } from "@geist/ui-react/lib/test-utils-isomorphic";
 import type { Meta, StoryObj } from "@storybook/react";
 import { encodeBytes32String } from "ethers";
-import { Chain, Hex, zeroHash } from "viem";
+import { type Chain, type Hex, zeroHash } from "viem";
 import { mainnet, optimism, optimismSepolia, sepolia } from "viem/chains";
 import { withToaster } from "../decorators/toaster";
 import { withWalletControl } from "../decorators/wallet-control";

--- a/apps/storybook/src/stories/attestations/AttestationFormWagmi.stories.tsx
+++ b/apps/storybook/src/stories/attestations/AttestationFormWagmi.stories.tsx
@@ -4,9 +4,16 @@ import {
 	SCHEMA_BY_NAME,
 	SCHEMA_FIXTURE_IS_A_FRIEND,
 } from "@geist/ui-react/lib/eas/attest.fixture";
-import { AttestationRequestData } from "@geist/ui-react/lib/eas/viem/onchain";
+import type { AttestationRequestData } from "@geist/ui-react/lib/eas/viem/onchain";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Account, Address, Chain, Hex, stringToHex, zeroHash } from "viem";
+import {
+	type Account,
+	type Address,
+	type Chain,
+	type Hex,
+	stringToHex,
+	zeroHash,
+} from "viem";
 import { sepolia } from "viem/chains";
 import { withToaster } from "../decorators/toaster";
 import { withMockAccount, withWagmiProvider } from "../decorators/wagmi";

--- a/apps/storybook/src/stories/codec/CodecForm.tsx
+++ b/apps/storybook/src/stories/codec/CodecForm.tsx
@@ -1,8 +1,8 @@
 import { base16 as base16S, base64 as base64S } from "@scure/base";
-import { Atom, atom, useAtom } from "jotai";
+import { Atom, type atom, useAtom } from "jotai";
 import { base16 } from "multiformats/bases/base16";
 import { base64 } from "multiformats/bases/base64";
-import { CID, MultibaseEncoder } from "multiformats/cid";
+import { CID, type MultibaseEncoder } from "multiformats/cid";
 import * as json from "multiformats/codecs/json";
 import { sha256 } from "multiformats/hashes/sha2";
 import { Suspense, useEffect, useMemo, useState } from "react";

--- a/apps/storybook/src/stories/filecoin/UploadDropzone.tsx
+++ b/apps/storybook/src/stories/filecoin/UploadDropzone.tsx
@@ -1,5 +1,6 @@
 import { Upload, X } from "lucide-react";
-import React, { useState, useRef, useCallback } from "react";
+import type React from "react";
+import { useCallback, useRef, useState } from "react";
 import { Alert, AlertDescription } from "#components/ui/alert";
 import { Button } from "#components/ui/button";
 import { Card } from "#components/ui/card";

--- a/apps/storybook/src/stories/filecoin/UploadForm.stories.tsx
+++ b/apps/storybook/src/stories/filecoin/UploadForm.stories.tsx
@@ -12,12 +12,16 @@ import {
 } from "@geist/ui-react/lib/filecoin/storacha/isomorphic";
 
 import { withToaster } from "../decorators/toaster";
-import { UploadFilesParams, UploadForm, UploadFormType } from "./UploadForm";
+import {
+	type UploadFilesParams,
+	UploadForm,
+	UploadFormType,
+} from "./UploadForm";
 import { uploadSuccessToast } from "./upload-toast";
 
 import config from "@geist/domain/config";
 import { IpfsGateway } from "@geist/ui-react/lib/filecoin/gateway";
-import { FileLike } from "@web3-storage/w3up-client/types";
+import type { FileLike } from "@web3-storage/w3up-client/types";
 
 const meta = {
 	title: "Filecoin/UploadForm",

--- a/apps/storybook/src/stories/filecoin/UploadForm.tsx
+++ b/apps/storybook/src/stories/filecoin/UploadForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { ZodType, z } from "zod";
+import { type ZodType, z } from "zod";
 
 import { FileInputField } from "@geist/ui-react/components/file/file-input-field";
 import { toast } from "@geist/ui-react/hooks/shadcn/use-toast";

--- a/apps/storybook/src/stories/privy/privy-login.stories.tsx
+++ b/apps/storybook/src/stories/privy/privy-login.stories.tsx
@@ -2,7 +2,7 @@ import {
 	PrivyLogin,
 	PrivyLoginProvider,
 } from "@geist/ui-react/components/privy/privy-login";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 interface PrivyLoginProps {
 	appId: string;

--- a/apps/storybook/src/stories/signature/SignatureForm.stories.tsx
+++ b/apps/storybook/src/stories/signature/SignatureForm.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Atom, atom, useAtom } from "jotai";
+import { type Atom, atom, useAtom } from "jotai";
 
 import { TYPED_DATA } from "@geist/domain/signature/type-data";
 import { SignatureForm } from "@geist/ui-react/components/signature/signature-form";
 import { useMemo } from "react";
 import {
 	http,
-	Account,
+	type Account,
 	createPublicClient,
 	createWalletClient,
 	verifyMessage,

--- a/apps/storybook/src/stories/token/TokenChip.stories.tsx
+++ b/apps/storybook/src/stories/token/TokenChip.stories.tsx
@@ -1,5 +1,5 @@
 import { TokenChip } from "@geist/ui-react/components/token/token-chip";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { mainnet, optimismSepolia } from "viem/chains";
 import { withWagmiProvider } from "../decorators/wagmi";
 

--- a/apps/storybook/src/stories/token/TokenChipWithInfo.stories.tsx
+++ b/apps/storybook/src/stories/token/TokenChipWithInfo.stories.tsx
@@ -1,5 +1,5 @@
 import { TokenChipWithInfo } from "@geist/ui-react/components/token/token-chip-with-info";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
 	title: "OnchainInfo/TokenChipWithInfo",

--- a/apps/storybook/src/stories/transfer-button/TransferButton.stories.tsx
+++ b/apps/storybook/src/stories/transfer-button/TransferButton.stories.tsx
@@ -1,5 +1,5 @@
 import { TransferButton } from "@geist/ui-react/components/transfer/transfer-button";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { useMemo, useState } from "react";
 import type { Account } from "viem";
 import { Label } from "#components/ui/label";

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": false
+			"recommended": false,
+			"style": {
+				"useImportType": "info"
+			}
 		}
 	},
 	"javascript": {

--- a/packages/domain/src/signature/type-data.ts
+++ b/packages/domain/src/signature/type-data.ts
@@ -2,7 +2,7 @@
 // and fixture from [micro-eth-signer](https://github.com/debuggingfuture/micro-eth-signer/blob/main/test/typed-data.test.js)
 
 import { EIP712Domain } from "micro-eth-signer/typed-data";
-import { TypedData } from "viem";
+import type { TypedData } from "viem";
 
 export const EIP721_TYPES = {
 	Person: [

--- a/packages/domain/src/signature/utils.test.ts
+++ b/packages/domain/src/signature/utils.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import {
-	Address,
-	Hex,
+	type Address,
+	type Hex,
 	hashMessage,
 	hashTypedData,
 	recoverAddress,

--- a/packages/ui-react/src/components/attestations/attestation-badge.tsx
+++ b/packages/ui-react/src/components/attestations/attestation-badge.tsx
@@ -1,4 +1,4 @@
-import { type Address } from "viem";
+import type { Address } from "viem";
 import { useChainId } from "wagmi";
 import { Badge } from "#components/shadcn/badge";
 import { useGetAttestations } from "#hooks/eas/use-get-attestations";

--- a/packages/ui-react/src/components/attestations/attestation-card.tsx
+++ b/packages/ui-react/src/components/attestations/attestation-card.tsx
@@ -1,7 +1,7 @@
 import { Label } from "@radix-ui/react-label";
 import { format } from "date-fns";
 import { useMemo } from "react";
-import { type Address, Hex } from "viem";
+import type { Address, Hex } from "viem";
 import { mainnet } from "viem/chains";
 import { useChainId } from "wagmi";
 import {
@@ -17,7 +17,7 @@ import { Skeleton } from "#components/shadcn/skeleton";
 import { useGetAttestationWithUid } from "#hooks/eas/use-get-attestation-with-uid.js";
 import { getShortHex } from "#lib/utils/hex";
 import { AttestationSchemaBadge } from "./attestation-schema-badge";
-import { AttestationMeta, asAttestationMeta } from "./attestations";
+import { type AttestationMeta, asAttestationMeta } from "./attestations";
 
 const AttestationCardContent = ({
 	chainId,

--- a/packages/ui-react/src/components/attestations/attestations-table.tsx
+++ b/packages/ui-react/src/components/attestations/attestations-table.tsx
@@ -1,4 +1,4 @@
-import { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { type Address, fromBlobs } from "viem";
 import { mainnet } from "viem/chains";
@@ -8,7 +8,7 @@ import { useGetAttestations } from "#hooks/eas/use-get-attestations";
 import { getEasscanAttestationUrl } from "#lib/eas/easscan";
 import { truncate } from "#lib/utils/hex";
 import { AttestationSchemaBadge } from "./attestation-schema-badge";
-import { AttestationMeta } from "./attestations";
+import type { AttestationMeta } from "./attestations";
 import { asAttestationMeta } from "./attestations";
 
 // This type is used to define the shape of our data.

--- a/packages/ui-react/src/components/attestations/attestations.ts
+++ b/packages/ui-react/src/components/attestations/attestations.ts
@@ -1,6 +1,6 @@
 import { format, formatDistance, subDays } from "date-fns";
 import type { Address } from "viem";
-import { AttestationQueryResult } from "#hooks/eas/use-get-attestations";
+import type { AttestationQueryResult } from "#hooks/eas/use-get-attestations";
 
 // TODO sync graphql type
 export const asAttestationMeta = (attestation: AttestationQueryResult) => {

--- a/packages/ui-react/src/components/attestations/upload-attestation.tsx
+++ b/packages/ui-react/src/components/attestations/upload-attestation.tsx
@@ -2,7 +2,7 @@ import config from "@geist/domain/config";
 import { Loader2, Upload } from "lucide-react";
 import { Button } from "#components/shadcn/button";
 import { useUploadAttestationWithLighthouse } from "#hooks/eas/use-upload-attestation";
-import { UploadAttestationParams } from "./attestations";
+import type { UploadAttestationParams } from "./attestations";
 
 // this is a controlled component that depends on an external state
 export function UploadAttestation(props: UploadAttestationParams) {

--- a/packages/ui-react/src/components/data-table.tsx
+++ b/packages/ui-react/src/components/data-table.tsx
@@ -1,6 +1,6 @@
 import {
-	ColumnDef,
-	SortingState,
+	type ColumnDef,
+	type SortingState,
 	flexRender,
 	getCoreRowModel,
 	getPaginationRowModel,

--- a/packages/ui-react/src/components/identity/name.tsx
+++ b/packages/ui-react/src/components/identity/name.tsx
@@ -1,4 +1,4 @@
-import { AddressOrEns } from "#hooks/ens/efp";
+import type { AddressOrEns } from "#hooks/ens/efp";
 import { useEnsData } from "#hooks/ens/use-efp-api";
 
 export const Name = ({ addressOrEns }: { addressOrEns: AddressOrEns }) => {

--- a/packages/ui-react/src/components/privy/privy-login.tsx
+++ b/packages/ui-react/src/components/privy/privy-login.tsx
@@ -1,5 +1,5 @@
 import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { Button } from "#components/shadcn/button";
 
 export function PrivyLoginProvider({

--- a/packages/ui-react/src/components/shadcn/badge.tsx
+++ b/packages/ui-react/src/components/shadcn/badge.tsx
@@ -1,5 +1,5 @@
 import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "#lib/shadcn/utils";
 

--- a/packages/ui-react/src/components/shadcn/form.tsx
+++ b/packages/ui-react/src/components/shadcn/form.tsx
@@ -1,11 +1,11 @@
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import {
 	Controller,
-	ControllerProps,
-	FieldPath,
-	FieldValues,
+	type ControllerProps,
+	type FieldPath,
+	type FieldValues,
 	FormProvider,
 	useFormContext,
 } from "react-hook-form";

--- a/packages/ui-react/src/components/signature/signature-form.tsx
+++ b/packages/ui-react/src/components/signature/signature-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { atom, useAtom } from "jotai";
+import { type atom, useAtom } from "jotai";
 import type { Hex } from "viem";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
+++ b/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AddressOrEns, EfpFollowerWithName } from "#hooks/ens/efp";
+import type { AddressOrEns, EfpFollowerWithName } from "#hooks/ens/efp";
 import { getNames } from "#hooks/ens/use-ensjs";
 import { FollowerListScrollable } from "./follower-list";
 

--- a/packages/ui-react/src/components/social-graph/follower-list.tsx
+++ b/packages/ui-react/src/components/social-graph/follower-list.tsx
@@ -1,6 +1,6 @@
 import { ScrollArea } from "#components/shadcn/scroll-area";
 import { Separator } from "#components/shadcn/separator";
-import { EfpFollowerWithName } from "#hooks/ens/efp";
+import type { EfpFollowerWithName } from "#hooks/ens/efp";
 
 export const FollowerListScrollable = ({
 	followers,

--- a/packages/ui-react/src/components/social-graph/name-and-follower-count-badge.tsx
+++ b/packages/ui-react/src/components/social-graph/name-and-follower-count-badge.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from "#components/shadcn/card";
 import { useEnsData, useUserStats } from "#hooks/ens/use-efp-api";
 
 import { useEffect, useState } from "react";
-import { AddressOrEns } from "#hooks/ens/efp";
+import type { AddressOrEns } from "#hooks/ens/efp";
 
 export type NameWithEfpFollowerCount = { name: string; followers: number };
 

--- a/packages/ui-react/src/components/token/token-chip-with-info.test.tsx
+++ b/packages/ui-react/src/components/token/token-chip-with-info.test.tsx
@@ -1,6 +1,6 @@
 import {
 	TokenChipWithInfo,
-	TokenChipWithInfoProps,
+	type TokenChipWithInfoProps,
 } from "@geist/ui-react/components/token/token-chip-with-info";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/ui-react/src/components/token/token-chip.tsx
+++ b/packages/ui-react/src/components/token/token-chip.tsx
@@ -1,4 +1,4 @@
-import { type Address, Chain, erc20Abi } from "viem";
+import { type Address, type Chain, erc20Abi } from "viem";
 import { mainnet } from "viem/chains";
 import { useConfig } from "wagmi";
 import { useTokenInfo } from "./token";

--- a/packages/ui-react/src/components/transactions/transaction-card-with-details.tsx
+++ b/packages/ui-react/src/components/transactions/transaction-card-with-details.tsx
@@ -1,5 +1,5 @@
 import type { Token } from "@geist/domain/token/token";
-import { TransactionMeta } from "@geist/domain/transaction/transaction";
+import type { TransactionMeta } from "@geist/domain/transaction/transaction";
 import { Label } from "@radix-ui/react-label";
 import { AddressBadge } from "#components/identity/address-badge";
 import {

--- a/packages/ui-react/src/components/transactions/transaction-table-with-details.tsx
+++ b/packages/ui-react/src/components/transactions/transaction-table-with-details.tsx
@@ -1,6 +1,9 @@
 import { Skeleton } from "#components/shadcn/skeleton";
 import { useGetTransactions } from "#hooks/data/use-blockscout";
-import { GetTxnByFilterQuery, asTransactionMeta } from "#lib/blockscout/api";
+import {
+	type GetTxnByFilterQuery,
+	asTransactionMeta,
+} from "#lib/blockscout/api";
 import { Explorer } from "#lib/explorer/url";
 import { TransactionTable } from "./transaction-table";
 

--- a/packages/ui-react/src/components/transactions/transaction-table.tsx
+++ b/packages/ui-react/src/components/transactions/transaction-table.tsx
@@ -1,6 +1,6 @@
 import { resolveChainById } from "@geist/domain/chain/chain-resolver";
-import { TransactionMeta } from "@geist/domain/transaction/transaction";
-import { ColumnDef } from "@tanstack/react-table";
+import type { TransactionMeta } from "@geist/domain/transaction/transaction";
+import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown, ExternalLink } from "lucide-react";
 import { formatEther } from "viem";
 import { DataTable } from "#components/data-table";

--- a/packages/ui-react/src/components/transfer/transfer-button.tsx
+++ b/packages/ui-react/src/components/transfer/transfer-button.tsx
@@ -1,10 +1,13 @@
-import { MutationOptions } from "@tanstack/react-query";
-import { Config, SendTransactionErrorType } from "@wagmi/core";
+import type { MutationOptions } from "@tanstack/react-query";
+import type { Config, SendTransactionErrorType } from "@wagmi/core";
 import { Loader2 } from "lucide-react";
-import { Account, parseEther } from "viem";
+import { type Account, parseEther } from "viem";
 import { useSendTransaction } from "wagmi";
-import { SendTransactionData, SendTransactionVariables } from "wagmi/query";
-import { Button, ButtonProps } from "#components/shadcn/button";
+import type {
+	SendTransactionData,
+	SendTransactionVariables,
+} from "wagmi/query";
+import { Button, type ButtonProps } from "#components/shadcn/button";
 
 type TransferButtonProps = {
 	/** Amount to transfer in ETH */

--- a/packages/ui-react/src/hooks/data/use-blockscout.ts
+++ b/packages/ui-react/src/hooks/data/use-blockscout.ts
@@ -1,7 +1,7 @@
 import type { TransactionMeta } from "@geist/domain/transaction/transaction";
 import { useQuery } from "@tanstack/react-query";
 import {
-	GetTxnByFilterQuery,
+	type GetTxnByFilterQuery,
 	asTransactionMeta,
 	getTransaction,
 	getTxnsByFilter,

--- a/packages/ui-react/src/hooks/eas/sdk/use-attestation.ts
+++ b/packages/ui-react/src/hooks/eas/sdk/use-attestation.ts
@@ -1,12 +1,12 @@
 import { SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { NO_EXPIRATION } from "@geist/ui-react/lib/eas/request";
 import type { AttestationRequestData } from "@geist/ui-react/lib/eas/viem/onchain";
-import { Signer, ZeroHash } from "ethers";
+import { type Signer, ZeroHash } from "ethers";
 import { useMemo } from "react";
 import {
 	Account,
-	Address,
-	Chain,
+	type Address,
+	type Chain,
 	Hex,
 	createWalletClient,
 	stringToHex,

--- a/packages/ui-react/src/hooks/eas/use-get-attestation-with-uid.tsx
+++ b/packages/ui-react/src/hooks/eas/use-get-attestation-with-uid.tsx
@@ -1,4 +1,4 @@
-import { type Attestation } from "@geist/graphql/eas/graphql";
+import type { Attestation } from "@geist/graphql/eas/graphql";
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { gql, rawRequest } from "graphql-request";
 import { getEasscanEndpoint } from "#lib/eas/easscan";

--- a/packages/ui-react/src/hooks/eas/use-get-attestations.int.test.tsx
+++ b/packages/ui-react/src/hooks/eas/use-get-attestations.int.test.tsx
@@ -4,7 +4,7 @@ import { useGetAttestations } from "./use-get-attestations";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
+import type React from "react";
 import type { Address } from "viem";
 
 /**

--- a/packages/ui-react/src/hooks/eas/use-get-attestations.ts
+++ b/packages/ui-react/src/hooks/eas/use-get-attestations.ts
@@ -1,6 +1,6 @@
 import { gql } from "@geist/graphql";
 import type { Attestation } from "@geist/graphql/eas/graphql";
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { rawRequest, request } from "graphql-request";
 import { type Address, Hex } from "viem";
 import { getEasscanEndpoint } from "#lib/eas/easscan";

--- a/packages/ui-react/src/hooks/eas/use-upload-attestation.ts
+++ b/packages/ui-react/src/hooks/eas/use-upload-attestation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useWalletClient } from "wagmi";
-import { UploadAttestationParams } from "#components/attestations/attestations";
+import type { UploadAttestationParams } from "#components/attestations/attestations";
 import { createGetAttestationWithUidQueryOptions } from "#hooks/eas/use-get-attestation-with-uid.js";
 import { useToast } from "#hooks/shadcn/use-toast";
 import {

--- a/packages/ui-react/src/hooks/ens/use-efp-api.int.test.tsx
+++ b/packages/ui-react/src/hooks/ens/use-efp-api.int.test.tsx
@@ -11,7 +11,7 @@ import {
 import { BY_USER } from "@geist/domain/user.fixture";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
+import type React from "react";
 
 describe("endpoints", () => {
 	test("#getEndpointUserFollowing", () => {

--- a/packages/ui-react/src/hooks/ens/use-efp-api.ts
+++ b/packages/ui-react/src/hooks/ens/use-efp-api.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Address } from "viem";
-import {
+import type {
 	AddressOrEns,
 	EfpApiOptions,
 	EfpEnsData,

--- a/packages/ui-react/src/hooks/ens/use-ensjs.ts
+++ b/packages/ui-react/src/hooks/ens/use-ensjs.ts
@@ -1,6 +1,6 @@
 import { addEnsContracts } from "@ensdomains/ensjs";
 import { batch, getName } from "@ensdomains/ensjs/public";
-import { http, Address, createPublicClient } from "viem";
+import { http, type Address, createPublicClient } from "viem";
 import { mainnet } from "viem/chains";
 
 export const createEnsClient = () => {

--- a/packages/ui-react/src/hooks/identity/use-identity.ts
+++ b/packages/ui-react/src/hooks/identity/use-identity.ts
@@ -1,4 +1,4 @@
-import { AddressOrEns } from "#hooks/ens/efp.js";
+import type { AddressOrEns } from "#hooks/ens/efp.js";
 import { useEnsData } from "#hooks/ens/use-efp-api";
 
 export enum MetadataService {

--- a/packages/ui-react/src/hooks/signature/use-sign.ts
+++ b/packages/ui-react/src/hooks/signature/use-sign.ts
@@ -1,7 +1,7 @@
 import { signMessage } from "@wagmi/core";
 import * as typed from "micro-eth-signer/typed-data";
 import {
-	EIP712Domain,
+	type EIP712Domain,
 	GetType,
 	TypedData,
 	signTyped,
@@ -9,7 +9,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { useAccount, useConfig, useSignMessage } from "wagmi";
 
-import { atom, useAtom } from "jotai";
+import { type atom, useAtom } from "jotai";
 import { addr } from "micro-eth-signer";
 
 import { type Hex, SignType } from "@geist/domain/signature/sign";

--- a/packages/ui-react/src/lib/blockscout/api.ts
+++ b/packages/ui-react/src/lib/blockscout/api.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	TokenTransfer,
 	TransactionMeta,
 } from "@geist/domain/transaction/transaction";

--- a/packages/ui-react/src/lib/blockscout/url.ts
+++ b/packages/ui-react/src/lib/blockscout/url.ts
@@ -1,6 +1,6 @@
 import { getBlockscoutChainEndpoint } from "#lib/blockscout/chain";
 import {
-	CreateBlockExplorerUrlArgs,
+	type CreateBlockExplorerUrlArgs,
 	createBlockExplorerUrlWithEip3091,
 } from "#lib/explorer/url";
 

--- a/packages/ui-react/src/lib/eas/attest.fixture.ts
+++ b/packages/ui-react/src/lib/eas/attest.fixture.ts
@@ -1,7 +1,7 @@
 import {
-	AttestationShareablePackageObject,
+	type AttestationShareablePackageObject,
 	OffchainAttestationVersion,
-	SignedOffchainAttestation,
+	type SignedOffchainAttestation,
 } from "@ethereum-attestation-service/eas-sdk";
 import { mainnet, optimism, optimismSepolia, sepolia } from "viem/chains";
 import { NO_EXPIRATION } from "./request";

--- a/packages/ui-react/src/lib/eas/events.ts
+++ b/packages/ui-react/src/lib/eas/events.ts
@@ -1,4 +1,4 @@
-import { TransactionReceipt, parseEventLogs } from "viem";
+import { type TransactionReceipt, parseEventLogs } from "viem";
 import { EAS_ABI } from "./abi";
 
 export enum Event {

--- a/packages/ui-react/src/lib/eas/offchain-utils.test.ts
+++ b/packages/ui-react/src/lib/eas/offchain-utils.test.ts
@@ -1,14 +1,14 @@
 import {
 	EAS,
 	Offchain,
-	SignedOffchainAttestation,
+	type SignedOffchainAttestation,
 	ZERO_ADDRESS,
 	createOffchainURL as createOffchainURLSdk,
 	decodeBase64ZippedBase64,
 	zipAndEncodeToBase64 as zipAndEncodeToBase64Sdk,
 } from "@ethereum-attestation-service/eas-sdk";
 import { describe, expect, test } from "vitest";
-import { Spec, TEST_ATTESTATIONS } from "./attest.fixture";
+import { type Spec, TEST_ATTESTATIONS } from "./attest.fixture";
 import {
 	createOffchainURL,
 	zipAndEncodeToBase64,

--- a/packages/ui-react/src/lib/eas/request.ts
+++ b/packages/ui-react/src/lib/eas/request.ts
@@ -1,4 +1,4 @@
-import { Signature } from "./sdk/offchain/typed-data-handler";
+import type { Signature } from "./sdk/offchain/typed-data-handler";
 
 export const NO_EXPIRATION = 0n;
 

--- a/packages/ui-react/src/lib/eas/schema-encoder.ts
+++ b/packages/ui-react/src/lib/eas/schema-encoder.ts
@@ -3,7 +3,7 @@
  */
 
 import { isCID } from "@geist/domain/codec";
-import { CID, MultihashDigest } from "multiformats";
+import { CID, type MultihashDigest } from "multiformats";
 import {
 	type AbiFunction,
 	type AbiParameter,

--- a/packages/ui-react/src/lib/eas/sdk/eas.ts
+++ b/packages/ui-react/src/lib/eas/sdk/eas.ts
@@ -2,9 +2,9 @@ import {
 	EAS,
 	NO_EXPIRATION,
 	SchemaEncoder,
-	SchemaValue,
+	type SchemaValue,
 } from "@ethereum-attestation-service/eas-sdk";
-import { Signer } from "ethers";
+import type { Signer } from "ethers";
 
 export type CreateAttestationRequestParams = any;
 

--- a/packages/ui-react/src/lib/eas/sdk/offchain/delegated.ts
+++ b/packages/ui-react/src/lib/eas/sdk/offchain/delegated.ts
@@ -1,9 +1,9 @@
 import omit from "lodash/omit";
 import {
-	EIP712MessageTypes,
-	EIP712Params,
+	type EIP712MessageTypes,
+	type EIP712Params,
 	EIP712Response,
-	EIP712Types,
+	type EIP712Types,
 	TypeDataSigner,
 	// TypedDataHandler,
 } from "#lib/eas/sdk/offchain/typed-data-handler";

--- a/packages/ui-react/src/lib/eas/sdk/offchain/offchain-utils.ts
+++ b/packages/ui-react/src/lib/eas/sdk/offchain/offchain-utils.ts
@@ -1,7 +1,7 @@
 import {
 	type AttestationShareablePackageObject,
-	CompactAttestationShareablePackageObject,
-	EIP712MessageTypes,
+	type CompactAttestationShareablePackageObject,
+	type EIP712MessageTypes,
 	OffchainAttestationVersion,
 } from "@ethereum-attestation-service/eas-sdk";
 import { stringifyWithBigInt } from "@geist/domain/util";
@@ -9,8 +9,8 @@ import { ZERO_ADDRESS } from "@geist/ui-react/lib/constants";
 import { base64 } from "@scure/base";
 import { zlibSync } from "fflate";
 import {
-	Address,
-	Hex,
+	type Address,
+	type Hex,
 	encodeAbiParameters,
 	encodePacked,
 	keccak256,

--- a/packages/ui-react/src/lib/eas/sdk/offchain/schema-encoder.ts
+++ b/packages/ui-react/src/lib/eas/sdk/offchain/schema-encoder.ts
@@ -4,7 +4,7 @@ import {
 	encodeBytes32String,
 	isBytesLike,
 } from "ethers";
-import { CID, MultihashDigest } from "multiformats";
+import { CID, type MultihashDigest } from "multiformats";
 import { ZERO_ADDRESS } from "#lib/constants";
 
 export type SchemaValue =

--- a/packages/ui-react/src/lib/eas/sdk/offchain/typed-data-handler.ts
+++ b/packages/ui-react/src/lib/eas/sdk/offchain/typed-data-handler.ts
@@ -1,23 +1,23 @@
-import { OffchainAttestationType } from "@ethereum-attestation-service/eas-sdk";
+import type { OffchainAttestationType } from "@ethereum-attestation-service/eas-sdk";
 import {
 	AbiCoder,
-	Addressable,
+	type Addressable,
 	Signature as Sig,
-	TypedDataDomain,
-	TypedDataField,
+	type TypedDataDomain,
+	type TypedDataField,
 	getAddress,
 	hexlify,
 	toUtf8Bytes,
 	verifyTypedData,
 } from "ethers";
 import {
-	Hex,
+	type Hex,
 	encodeAbiParameters,
 	encodePacked,
 	keccak256,
 	parseAbiParameters,
 } from "viem";
-import { DelegatedConfig } from "#lib/eas/sdk/offchain/delegated";
+import type { DelegatedConfig } from "#lib/eas/sdk/offchain/delegated";
 import { EIP712_NAME } from "#lib/eas/versions";
 
 export interface Signature {

--- a/packages/ui-react/src/lib/eas/typed-data.test.ts
+++ b/packages/ui-react/src/lib/eas/typed-data.test.ts
@@ -3,7 +3,7 @@ import {
 	EAS,
 	OFFCHAIN_ATTESTATION_TYPES,
 	Offchain,
-	OffchainAttestationType,
+	type OffchainAttestationType,
 	OffchainAttestationVersion,
 } from "@ethereum-attestation-service/eas-sdk";
 import { AbiCoder, keccak256 as keccak256Ethers, toUtf8Bytes } from "ethers";
@@ -17,7 +17,7 @@ import {
 } from "viem";
 import { describe, expect, test } from "vitest";
 import { EAS_CONTRACT_ADDRESS } from "./abi";
-import { DelegatedConfig } from "./sdk/offchain/delegated";
+import type { DelegatedConfig } from "./sdk/offchain/delegated";
 import {
 	DelegatedAttestationVersion,
 	getDomainSeparatorDefault,

--- a/packages/ui-react/src/lib/eas/viem/offchain.int.test.ts
+++ b/packages/ui-react/src/lib/eas/viem/offchain.int.test.ts
@@ -1,8 +1,8 @@
 import {
-	EAS,
+	type EAS,
 	NO_EXPIRATION,
 	Offchain,
-	OffchainAttestationTypedData,
+	type OffchainAttestationTypedData,
 	OffchainAttestationVersion,
 	ZERO_BYTES,
 	ZERO_BYTES32,
@@ -10,8 +10,8 @@ import {
 } from "@ethereum-attestation-service/eas-sdk";
 import config from "@geist/domain/config";
 import { BY_USER } from "@geist/domain/user.fixture";
-import { Signature, Signer, encodeBytes32String, ethers } from "ethers";
-import { http, Address, createWalletClient, custom, zeroHash } from "viem";
+import { Signature, type Signer, encodeBytes32String, ethers } from "ethers";
+import { http, type Address, createWalletClient, custom, zeroHash } from "viem";
 import type { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { optimismSepolia, sepolia } from "viem/chains";

--- a/packages/ui-react/src/lib/eas/viem/offchain.ts
+++ b/packages/ui-react/src/lib/eas/viem/offchain.ts
@@ -1,8 +1,15 @@
-import { http, Account, Address, Chain, Hex, createWalletClient } from "viem";
+import {
+	http,
+	type Account,
+	type Address,
+	type Chain,
+	type Hex,
+	createWalletClient,
+} from "viem";
 import {
 	OFFCHAIN_ATTESTATION_TYPES,
-	OffchainAttestationTypedData,
-	OffchainAttestationVersion,
+	type OffchainAttestationTypedData,
+	type OffchainAttestationVersion,
 } from "#lib/eas/sdk/offchain/offchain";
 import { getOffchainUID } from "#lib/eas/sdk/offchain/offchain-utils";
 

--- a/packages/ui-react/src/lib/eas/viem/onchain.e2e.test.ts
+++ b/packages/ui-react/src/lib/eas/viem/onchain.e2e.test.ts
@@ -5,7 +5,7 @@ import {
 	createTestClientConfig,
 	createTestEthersSigner,
 } from "@geist/ui-react/lib/test-utils-isomorphic";
-import { http, Hex, createWalletClient, zeroHash } from "viem";
+import { http, type Hex, createWalletClient, zeroHash } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 import { beforeEach, describe, expect, it, test } from "vitest";

--- a/packages/ui-react/src/lib/eas/viem/onchain.ts
+++ b/packages/ui-react/src/lib/eas/viem/onchain.ts
@@ -6,11 +6,11 @@ import {
 	Account,
 	Chain,
 	Client,
-	Hex,
-	ReadContractParameters,
+	type Hex,
+	type ReadContractParameters,
 	TransactionReceipt,
 	Transport,
-	WalletClient,
+	type WalletClient,
 	createPublicClient,
 } from "viem";
 import {
@@ -21,7 +21,7 @@ import {
 import { sepolia } from "viem/chains";
 import { EAS_ABI, EAS_CONTRACT_ADDRESS } from "#lib/eas/abi";
 import { getUIDsFromAttestReceipt } from "#lib/eas/events";
-import { RevocationRequest } from "#lib/eas/request";
+import type { RevocationRequest } from "#lib/eas/request";
 import type { SchemaItem } from "#lib/eas/sdk/eas";
 
 // TODO align on offchain

--- a/packages/ui-react/src/lib/explorer/url.ts
+++ b/packages/ui-react/src/lib/explorer/url.ts
@@ -1,5 +1,10 @@
 import { getBlock } from "viem/actions";
-import { Chain, filecoin, filecoinCalibration, mainnet } from "viem/chains";
+import {
+	type Chain,
+	filecoin,
+	filecoinCalibration,
+	mainnet,
+} from "viem/chains";
 
 export enum Explorer {
 	Blockscout = "blockscout",

--- a/packages/ui-react/src/lib/filecoin/akave/client.ts
+++ b/packages/ui-react/src/lib/filecoin/akave/client.ts
@@ -1,4 +1,4 @@
-import ky, { DownloadProgress } from "ky";
+import ky, { type DownloadProgress } from "ky";
 
 export interface AkaveFile {
 	Name: string;

--- a/packages/ui-react/src/lib/filecoin/gateway.ts
+++ b/packages/ui-react/src/lib/filecoin/gateway.ts
@@ -1,4 +1,4 @@
-import { GatewayStrategy } from "#lib/filecoin/gateway-strategy";
+import type { GatewayStrategy } from "#lib/filecoin/gateway-strategy";
 import { getLighthouseGatewayUrl } from "#lib/filecoin/lighthouse/isomorphic";
 
 export enum IpfsGateway {

--- a/packages/ui-react/src/lib/filecoin/lighthouse/browser.ts
+++ b/packages/ui-react/src/lib/filecoin/lighthouse/browser.ts
@@ -1,11 +1,11 @@
 import { lighthouseConfig } from "@lighthouse-web3/sdk/dist/lighthouse.config";
 // This is custom implementation of lighthouse browser client due to below issue and preference of ky for timeout
 // https://github.com/lighthouse-web3/lighthouse-package/issues/119
-import {
+import type {
 	DealParameters,
 	UploadFileReturnType,
 } from "@lighthouse-web3/sdk/dist/types";
-import ky, { DownloadProgress } from "ky";
+import ky, { type DownloadProgress } from "ky";
 
 export const createLighthouseEndpoint = (isWrapWithDirectory = false) => {
 	const search = new URLSearchParams(

--- a/packages/ui-react/src/lib/filecoin/lighthouse/isomorphic.ts
+++ b/packages/ui-react/src/lib/filecoin/lighthouse/isomorphic.ts
@@ -1,10 +1,10 @@
 import kavach from "@lighthouse-web3/kavach";
 import lighthouse from "@lighthouse-web3/sdk";
-import { IUploadProgressCallback } from "@lighthouse-web3/sdk/dist/types";
-import ky, { DownloadProgress } from "ky";
+import type { IUploadProgressCallback } from "@lighthouse-web3/sdk/dist/types";
+import ky, { type DownloadProgress } from "ky";
 import { http, type Account, createWalletClient } from "viem";
 import { sepolia } from "viem/chains";
-import { GatewayStrategy } from "#lib/filecoin/gateway-strategy";
+import type { GatewayStrategy } from "#lib/filecoin/gateway-strategy";
 import { uploadFiles as uploadFilesLighthouse } from "#lib/filecoin/lighthouse/browser";
 // import { CID } from 'multiformats/cid'
 

--- a/packages/ui-react/src/lib/filecoin/storacha/client.int.test.ts
+++ b/packages/ui-react/src/lib/filecoin/storacha/client.int.test.ts
@@ -1,7 +1,7 @@
 // Note test case at https://github.com/storacha/w3up/blob/main/packages/w3up-client/test/client.test.js
 
 import config from "@geist/domain/config";
-import { Client, create } from "@web3-storage/w3up-client";
+import { type Client, create } from "@web3-storage/w3up-client";
 import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
 import * as Proof from "@web3-storage/w3up-client/proof";
 import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";

--- a/packages/ui-react/src/lib/filecoin/url.ts
+++ b/packages/ui-react/src/lib/filecoin/url.ts
@@ -1,11 +1,11 @@
-import { Chain, filecoin, filecoinCalibration } from "viem/chains";
+import { type Chain, filecoin, filecoinCalibration } from "viem/chains";
 import {
-	CreateBlockExplorerUrlArgs,
-	CreateExplorerUrl,
+	type CreateBlockExplorerUrlArgs,
+	type CreateExplorerUrl,
 	Explorer,
-	ExplorerConfig,
-	ExplorerEntity,
-	ExplorerParams,
+	type ExplorerConfig,
+	type ExplorerEntity,
+	type ExplorerParams,
 	createBlockExplorerUrlWithEip3091,
 } from "#lib/explorer/url";
 

--- a/packages/ui-react/src/lib/trustwallet-chain.ts
+++ b/packages/ui-react/src/lib/trustwallet-chain.ts
@@ -1,4 +1,4 @@
-import { Chain } from "viem";
+import type { Chain } from "viem";
 import { optimism } from "viem/chains";
 
 // https://github.com/trustwallet/assets


### PR DESCRIPTION
configured `useImportType` after #68

note: on the ohter hand biome do not support regex for `noRestrictedImports` so not possible to ban relative path but only particular modules

```
			"nursery": {
				"noRestrictedImports": {
					"level": "error",
					"options": {
						"paths": {
							"lodash": "Using lodash is not encouraged"
						}
					}
				}
			}
```

<sub><a href="https://huly.app/guest/geist?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdmODkzNGYxNDRmNTg1YWU1MzY3MGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZGVidWdnLWdlaXN0LTY3NDAzNjhlLTU0NTgxY2VhOWEtYmNhZDgwIn0.j2RALuSD3m894T7ZJTBpcCfhFYdVjSbBplDFCbOqWVI">Huly&reg;: <b>DAPPK-70</b></a></sub>